### PR TITLE
Update Rancher Desktop to 1.9.1 and .msi

### DIFF
--- a/automatic/rancher-desktop/rancher-desktop.nuspec
+++ b/automatic/rancher-desktop/rancher-desktop.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>rancher-desktop</id>
-    <version>1.8.1</version>
+    <version>1.9.1</version>
     <packageSourceUrl>https://github.com/usm-community/chocolatey-packages/tree/main/automatic/rancher-desktop</packageSourceUrl>
     <owners>overage</owners>
     <!-- ============================== -->

--- a/automatic/rancher-desktop/tools/chocolateyinstall.ps1
+++ b/automatic/rancher-desktop/tools/chocolateyinstall.ps1
@@ -3,13 +3,13 @@ $url = 'https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
-  fileType       = 'EXE'
+  fileType       = 'MSI'
   url            = $url
   softwareName   = 'Rancher Desktop*'
   checksum       = '5f7bc72fc159864b84464f6dc967be5c7379529b04c983a2d5e1f85b6ff3f358'
   checksumType   = 'sha256'
-  silentArgs     = '/S'
-  validExitCodes = @(0)
+  silentArgs     = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
+  validExitCodes = @(0, 3010, 1641)
 }
 
 Install-ChocolateyPackage @packageArgs

--- a/automatic/rancher-desktop/tools/chocolateyinstall.ps1
+++ b/automatic/rancher-desktop/tools/chocolateyinstall.ps1
@@ -1,12 +1,12 @@
 ﻿$ErrorActionPreference = 'Stop'
-$url = 'https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.8.1/Rancher.Desktop.Setup.1.8.1.exe'
+$url = 'https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.9.1/Rancher.Desktop.Setup.1.9.1.msi'
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   fileType       = 'EXE'
   url            = $url
   softwareName   = 'Rancher Desktop*'
-  checksum       = '53e4712e417a37197637314944be27c944ee2b568e65f62f154c2543c6f82a97'
+  checksum       = '5f7bc72fc159864b84464f6dc967be5c7379529b04c983a2d5e1f85b6ff3f358'
   checksumType   = 'sha256'
   silentArgs     = '/S'
   validExitCodes = @(0)

--- a/automatic/rancher-desktop/update.ps1
+++ b/automatic/rancher-desktop/update.ps1
@@ -14,7 +14,7 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
     $latest_asset = (Invoke-RestMethod -Uri $releases).assets
 
-    $url = $latest_asset | Where-Object browser_download_url -Match 'Rancher\.Desktop\.Setup\..*\.exe' | Select-Object -First 1 -ExpandProperty browser_download_url
+    $url = $latest_asset | Where-Object browser_download_url -Match 'Rancher\.Desktop\.Setup\..*\.msi' | Select-Object -First 1 -ExpandProperty browser_download_url
     $version = Get-Version $url
 
     return @{


### PR DESCRIPTION
@overag3 Rancher Desktop doesn't provide .exe installers anymore (See https://github.com/rancher-sandbox/rancher-desktop/issues/4640), thats why this package got outdated.